### PR TITLE
Fix HTML syntax

### DIFF
--- a/src/pages/index.pug
+++ b/src/pages/index.pug
@@ -25,7 +25,7 @@ html(lang="ja")
     meta(name="format-detection" content="telephone=no,email=no,address=no")
     title= titleText
     meta(name="description" content=descriptionText)
-    link(rel="canonical" content=`${canonicalURL}`)
+    link(rel="canonical" href=`${canonicalURL}`)
     include _head/preload
     include _head/ogp
     link(rel="stylesheet" href="/root.css")


### PR DESCRIPTION
生成されたHTMLが[W3CのValidator](https://validator.w3.org/)を通るように修正する。
