### PR TITLE
direnvに対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ typings/
 # dotenv environment variables file
 .env
 
+# direnv environment variables file
+.envrc
+
 # next.js build output
 .next
 


### PR DESCRIPTION
[direnv](https://direnv.net/)に対応する。

- [x] `.envrc`を`.gitignore`に追加
