### PR TITLE
ソーシャルリンクの最大幅を50%にする

### DIFF
--- a/src/styles/root.less
+++ b/src/styles/root.less
@@ -52,6 +52,7 @@ h1,
     flex: 1 1 auto;
     text-align: center;
     max-width: 50%;
+    min-width: max-content;
 
     & > a {
       @bg-color: $background-color;

--- a/src/styles/root.less
+++ b/src/styles/root.less
@@ -51,6 +51,7 @@ h1,
     margin: @social-links-gap;
     flex: 1 1 auto;
     text-align: center;
+    max-width: 50%;
 
     & > a {
       @bg-color: $background-color;

--- a/src/styles/root.less
+++ b/src/styles/root.less
@@ -51,8 +51,11 @@ h1,
     margin: @social-links-gap;
     flex: 1 1 auto;
     text-align: center;
-    max-width: 50%;
-    min-width: max-content;
+
+    @supports (min-width: max-content) {
+      max-width: 50%;
+      min-width: max-content;
+    }
 
     & > a {
       @bg-color: $background-color;


### PR DESCRIPTION
リンクが一つだけの列で、リンクが横いっぱいに広がっているのはダサく感じる。
最大幅を50%に設定するのはどうだろう？
