### PR TITLE
ソーシャルリンクのスタイルを、リンク先のURLで分けるように変更

### DIFF
--- a/src/pages/index.pug
+++ b/src/pages/index.pug
@@ -23,38 +23,31 @@ socialLinkList:
   - type: twitter
     screenName: sounisi5011R18G
     id: '768680194244612096'
-  - type: github
-    url: https://github.com/sounisi5011
+  - url: https://github.com/sounisi5011
     title: GitHub
     serviceName: 'GitHub: '
     userName: sounisi5011
-  - type: qiita
-    url: https://qiita.com/sounisi5011
+  - url: https://qiita.com/sounisi5011
     title: Qiita
     serviceName: 'Qiita: '
     userName: sounisi5011
-  - type: pixiv
-    url: https://www.pixiv.net/member.php?id=3910454
+  - url: https://www.pixiv.net/member.php?id=3910454
     title: pixiv
     serviceName: 'pixiv: '
     userName: 3910454
-  - type: furaffinity
-    url: https://www.furaffinity.net/user/sounisi5011/
+  - url: https://www.furaffinity.net/user/sounisi5011/
     title: Fur Affinity
     serviceName: 'Fur Affinity: '
     userName: sounisi5011
-  - type: deviantart
-    url: https://www.deviantart.com/sounisi5011
+  - url: https://www.deviantart.com/sounisi5011
     title: DeviantArt
     serviceName: 'DeviantArt: '
     userName: sounisi5011
-  - type: e621
-    url: https://e621.net/user/show/306135
+  - url: https://e621.net/user/show/306135
     title: e621
     serviceName: 'e621: '
     userName: sounisi5011
-  - type: vore-pokemori
-    url: https://vore.pokemori.jp/list/?id=443&mode=show
+  - url: https://vore.pokemori.jp/list/?id=443&mode=show
     serviceName: なりきりチャット用キャラ名簿：
     userName: 壱冢想西
 ---
@@ -80,12 +73,12 @@ block content
     each socialLink in socialLinkList
       case socialLink.type
         when 'twitter'
-          li.twitter
+          li
             a(href=`https://twitter.com/intent/user?user_id=${socialLink.id}` target="_blank" title=`Twitter @${socialLink.screenName}`)
               span.service-name Twitter: 
               = `@${socialLink.screenName}`
         default
-          li(class=socialLink.type)
+          li
             a(href=socialLink.url target="_blank" title=socialLink.title)
               span.service-name= socialLink.serviceName
               = socialLink.userName

--- a/src/styles/root.less
+++ b/src/styles/root.less
@@ -125,7 +125,7 @@ h2 {
     }
 
     /* see https://about.twitter.com/ja/company/brand-resources.html */
-    &.twitter > a {
+    & > a[href^='https://twitter.com/'] {
       @bg-color: $background-color;
 
       background-color: #1da1f2;
@@ -149,7 +149,7 @@ h2 {
     }
 
     /* https://github.com/logos */
-    &.github > a {
+    & > a[href^="https://github.com/"] {
       @bg-color: $background-color;
       @text-color: $color;
 
@@ -175,7 +175,7 @@ h2 {
     }
 
     /* see https://www.pixiv.net/terms/?page=brand */
-    &.pixiv > a {
+    & > a[href^='https://www.pixiv.net/'] {
       @bg-color: $background-color;
 
       background-color: #ffffff;
@@ -200,7 +200,7 @@ h2 {
     }
 
     /* see https://help.qiita.com/ja/articles/others-brand-guideline */
-    &.qiita > a {
+    & > a[href^="https://qiita.com/"] {
       @bg-color: $background-color;
 
       background-color: #fff;
@@ -221,7 +221,7 @@ h2 {
       }
     }
 
-    &.e621 > a {
+    & > a[href^="https://e621.net/"] {
       background-color: #152f56;
       color: #b4c7d9;
 

--- a/src/styles/root.less
+++ b/src/styles/root.less
@@ -122,116 +122,116 @@ h2 {
       &:focus {
         background-color: lighten(@bg-color, 10%);
       }
-    }
 
-    /* see https://about.twitter.com/ja/company/brand-resources.html */
-    & > a[href^='https://twitter.com/'] {
-      @bg-color: $background-color;
+      /* see https://about.twitter.com/ja/company/brand-resources.html */
+      &[href^='https://twitter.com/'] {
+        @bg-color: $background-color;
 
-      background-color: #1da1f2;
-      color: #ffffff;
+        background-color: #1da1f2;
+        color: #ffffff;
 
-      &:hover,
-      &:focus {
-        background-color: lighten(@bg-color, 10%);
+        &:hover,
+        &:focus {
+          background-color: lighten(@bg-color, 10%);
+        }
+
+        &:before {
+          .fa-icon;
+          .fab;
+          content: @fa-var-twitter;
+          margin-right: @icon-right-space;
+        }
+
+        & .service-name {
+          .invisible-text;
+        }
       }
 
-      &:before {
-        .fa-icon;
-        .fab;
-        content: @fa-var-twitter;
-        margin-right: @icon-right-space;
+      /* https://github.com/logos */
+      &[href^="https://github.com/"] {
+        @bg-color: $background-color;
+        @text-color: $color;
+
+        background-color: #171516;
+        color: #ffffff;
+
+        &:hover,
+        &:focus {
+          background-color: @text-color;
+          color: @bg-color;
+        }
+
+        &:before {
+          .fa-icon;
+          .fab;
+          content: @fa-var-github;
+          margin-right: @icon-right-space;
+        }
+
+        & .service-name {
+          .invisible-text;
+        }
       }
 
-      & .service-name {
-        .invisible-text;
-      }
-    }
+      /* see https://www.pixiv.net/terms/?page=brand */
+      &[href^='https://www.pixiv.net/'] {
+        @bg-color: $background-color;
 
-    /* https://github.com/logos */
-    & > a[href^="https://github.com/"] {
-      @bg-color: $background-color;
-      @text-color: $color;
+        background-color: #ffffff;
+        color: #009cff;
 
-      background-color: #171516;
-      color: #ffffff;
+        &:hover,
+        &:focus {
+          background-color: darken(@bg-color, 10%);
+        }
 
-      &:hover,
-      &:focus {
-        background-color: @text-color;
-        color: @bg-color;
-      }
+        &:before {
+          .pseudo-image-resize(url("/images/icon-pixiv.png"));
+          min-width: 24px;
+          min-height: 24px;
+          vertical-align: top;
+          margin-right: @icon-right-space;
+        }
 
-      &:before {
-        .fa-icon;
-        .fab;
-        content: @fa-var-github;
-        margin-right: @icon-right-space;
-      }
-
-      & .service-name {
-        .invisible-text;
-      }
-    }
-
-    /* see https://www.pixiv.net/terms/?page=brand */
-    & > a[href^='https://www.pixiv.net/'] {
-      @bg-color: $background-color;
-
-      background-color: #ffffff;
-      color: #009cff;
-
-      &:hover,
-      &:focus {
-        background-color: darken(@bg-color, 10%);
+        & .service-name {
+          .invisible-text;
+        }
       }
 
-      &:before {
-        .pseudo-image-resize(url("/images/icon-pixiv.png"));
-        min-width: 24px;
-        min-height: 24px;
-        vertical-align: top;
-        margin-right: @icon-right-space;
+      /* see https://help.qiita.com/ja/articles/others-brand-guideline */
+      &[href^="https://qiita.com/"] {
+        @bg-color: $background-color;
+
+        background-color: #fff;
+        color: #4aac00;
+
+        &:hover,
+        &:focus {
+          background-color: darken(@bg-color, 10%);
+        }
+
+        &:before {
+          .pseudo-image-resize(url("/images/icon-qiita.png"));
+          margin-right: @icon-right-space;
+        }
+
+        & .service-name {
+          .invisible-text;
+        }
       }
 
-      & .service-name {
-        .invisible-text;
-      }
-    }
+      &[href^="https://e621.net/"] {
+        background-color: #152f56;
+        color: #b4c7d9;
 
-    /* see https://help.qiita.com/ja/articles/others-brand-guideline */
-    & > a[href^="https://qiita.com/"] {
-      @bg-color: $background-color;
+        &:hover,
+        &:focus {
+          color: #2e76b4;
+        }
 
-      background-color: #fff;
-      color: #4aac00;
-
-      &:hover,
-      &:focus {
-        background-color: darken(@bg-color, 10%);
-      }
-
-      &:before {
-        .pseudo-image-resize(url("/images/icon-qiita.png"));
-        margin-right: @icon-right-space;
-      }
-
-      & .service-name {
-        .invisible-text;
-      }
-    }
-
-    & > a[href^="https://e621.net/"] {
-      background-color: #152f56;
-      color: #b4c7d9;
-
-      &:hover,
-      &:focus {
-        color: #2e76b4;
-      }
-
-      & .service-name {
-        color: #fff;
+        & .service-name {
+          color: #fff;
+        }
       }
     }
   }

--- a/src/styles/root.less
+++ b/src/styles/root.less
@@ -123,8 +123,8 @@ h2 {
         background-color: lighten(@bg-color, 10%);
       }
 
-      /* see https://about.twitter.com/ja/company/brand-resources.html */
       &[href^='https://twitter.com/'] {
+        /* see https://about.twitter.com/ja/company/brand-resources.html */
         @bg-color: $background-color;
 
         background-color: #1da1f2;
@@ -147,8 +147,8 @@ h2 {
         }
       }
 
-      /* https://github.com/logos */
       &[href^="https://github.com/"] {
+        /* https://github.com/logos */
         @bg-color: $background-color;
         @text-color: $color;
 
@@ -173,8 +173,8 @@ h2 {
         }
       }
 
-      /* see https://www.pixiv.net/terms/?page=brand */
       &[href^='https://www.pixiv.net/'] {
+        /* see https://www.pixiv.net/terms/?page=brand */
         @bg-color: $background-color;
 
         background-color: #ffffff;
@@ -198,8 +198,8 @@ h2 {
         }
       }
 
-      /* see https://help.qiita.com/ja/articles/others-brand-guideline */
       &[href^="https://qiita.com/"] {
+        /* see https://help.qiita.com/ja/articles/others-brand-guideline */
         @bg-color: $background-color;
 
         background-color: #fff;


### PR DESCRIPTION
`li`要素の`class`属性は冗長で、省略することができる。
そこで、クラスに頼らずにスタイルを指定する変更を提案する。

この変更により、`index.pug`の`socialLinkList`の冗長さを解消できる。
