### PR TITLE
タイムゾーン「JST」を削除

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ Metalsmith(__dirname)
       (process.env.CONTEXT === 'production'
         ? process.env.URL
         : process.env.DEPLOY_URL) || '',
+    timezone: 9 * 60,
     title: 'sounisi5011.jp',
   })
   .source('./src/pages')

--- a/src/pages/_footer.pug
+++ b/src/pages/_footer.pug
@@ -41,7 +41,7 @@ footer.page
           span.bunsetsu= urlItem
   p
     | 最終更新日：
-    time(datetime=formatDate(modified || generated, '%Y-%m-%dT%H:%M:%SZ', 0)
+    time(datetime=formatDate(modified || generated, '%<time>', 0)
          itemprop=(modified ? "dateModified" : null))
       = formatDate(modified || generated, '%Y年%-m月%-d日 %H時%M分%S秒', timezone*60)
   p.license
@@ -63,13 +63,13 @@ footer.page
     small(lang="en")
       | Copyright ©
       |
-      time(datetime=formatDate(published || generated, '%Y-%m-%dT%H:%M:%SZ', 0)
+      time(datetime=formatDate(published || generated, '%<time>', 0)
            itemprop=(published ? "datePublished" : null))
         = formatDate(published || generated, '%Y', timezone*60)
       if published && modified
         | -
       if modified
-        time(datetime=formatDate(modified, '%Y-%m-%dT%H:%M:%SZ', 0)
+        time(datetime=formatDate(modified, '%<time>', 0)
              itemprop=((!published ? "datePublished " : "") + "dateModified"))
           = formatDate(modified, '%Y', timezone*60)
       |

--- a/src/pages/_footer.pug
+++ b/src/pages/_footer.pug
@@ -43,7 +43,7 @@ footer.page
     | 最終更新日：
     time(datetime=formatDate(modified || generated, '%Y-%m-%dT%H:%M:%SZ', 0)
          itemprop=(modified ? "dateModified" : null))
-      = formatDate(modified || generated, '%Y年%-m月%-d日 %H時%M分%S秒', 9 * 60*60)
+      = formatDate(modified || generated, '%Y年%-m月%-d日 %H時%M分%S秒', timezone*60)
   p.license
     a(rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja" hreflang="ja" target="_blank")
       if creativecommonsImageList
@@ -65,13 +65,13 @@ footer.page
       |
       time(datetime=formatDate(published || generated, '%Y-%m-%dT%H:%M:%SZ', 0)
            itemprop=(published ? "datePublished" : null))
-        = formatDate(published || generated, '%Y')
+        = formatDate(published || generated, '%Y', timezone*60)
       if published && modified
         | -
       if modified
         time(datetime=formatDate(modified, '%Y-%m-%dT%H:%M:%SZ', 0)
              itemprop=((!published ? "datePublished " : "") + "dateModified"))
-          = formatDate(modified, '%Y')
+          = formatDate(modified, '%Y', timezone*60)
       |
       |
       span(itemprop="author") sounisi5011

--- a/src/pages/_footer.pug
+++ b/src/pages/_footer.pug
@@ -43,7 +43,7 @@ footer.page
     | 最終更新日：
     time(datetime=formatDate(modified || generated, '%Y-%m-%dT%H:%M:%SZ', 0)
          itemprop=(modified ? "dateModified" : null))
-      = formatDate(modified || generated, '%Y年%-m月%-d日 %H:%M:%S', 9 * 60*60)
+      = formatDate(modified || generated, '%Y年%-m月%-d日 %H時%M分%S秒', 9 * 60*60)
   p.license
     a(rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja" hreflang="ja" target="_blank")
       if creativecommonsImageList

--- a/src/pages/_footer.pug
+++ b/src/pages/_footer.pug
@@ -43,7 +43,7 @@ footer.page
     | 最終更新日：
     time(datetime=formatDate(modified || generated, '%Y-%m-%dT%H:%M:%SZ', 0)
          itemprop=(modified ? "dateModified" : null))
-      = formatDate(modified || generated, '%Y年%-m月%-d日 %H:%M:%S JST', 9 * 60*60)
+      = formatDate(modified || generated, '%Y年%-m月%-d日 %H:%M:%S %:z', 9 * 60*60)
   p.license
     a(rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja" hreflang="ja" target="_blank")
       if creativecommonsImageList

--- a/src/pages/_footer.pug
+++ b/src/pages/_footer.pug
@@ -43,7 +43,7 @@ footer.page
     | 最終更新日：
     time(datetime=formatDate(modified || generated, '%Y-%m-%dT%H:%M:%SZ', 0)
          itemprop=(modified ? "dateModified" : null))
-      = formatDate(modified || generated, '%Y年%-m月%-d日 %H:%M:%S %:z', 9 * 60*60)
+      = formatDate(modified || generated, '%Y年%-m月%-d日 %H:%M:%S', 9 * 60*60)
   p.license
     a(rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja" hreflang="ja" target="_blank")
       if creativecommonsImageList

--- a/src/utils/template-functions.js
+++ b/src/utils/template-functions.js
@@ -257,6 +257,19 @@ function formatDate(
     '%::z': `${timezoneSign}${timezoneH}:${timezoneM}:${timezoneS}`,
     /* eslint-enable sort-keys */
   };
+  /**
+   * @see https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-global-date-and-time-string
+   */
+  replaceDict['%<time>'] = [
+    [replaceDict['%Y'], replaceDict['%m'], replaceDict['%d']].join('-'),
+    'T',
+    [
+      replaceDict['%H'],
+      replaceDict['%M'],
+      replaceDict['%S'] + '.' + replaceDict['%3N'],
+    ].join(':'),
+    timezoneSec === 0 ? 'Z' : replaceDict['%:z'],
+  ].join('');
   /*
    * 置換する
    * Note: この実装では、例えば"constructor"のような値を

--- a/src/utils/template-functions.js
+++ b/src/utils/template-functions.js
@@ -184,10 +184,6 @@ function formatDate(
    */
   timezoneSec = Math.trunc(timezoneSec);
   /*
-   * Dateオブジェクトから、タイムゾーンの秒数を取得する
-   */
-  const systemTimezoneSec = date.getTimezoneOffset() * -1 * 60;
-  /*
    * timezoneSecの値が範囲内かを判定
    */
   if (!(-(24 * 3600) < timezoneSec)) {
@@ -208,8 +204,11 @@ function formatDate(
   /*
    * タイムゾーンに合わせて、Dateオブジェクトの時間をずらす
    */
-  const unixtime = date.getTime();
-  date = new Date(unixtime - (systemTimezoneSec - timezoneSec) * 1000);
+  if (timezoneSec !== 0) {
+    const unixtime = date.getTime();
+    const timezoneMSec = timezoneSec * 1000;
+    date = new Date(unixtime + timezoneMSec);
+  }
   /*
    * タイムゾーンの文字列に使用する値を求める
    */
@@ -224,24 +223,24 @@ function formatDate(
   /*
    * ナノ秒の数値文字列を生成する
    */
-  const ns = String(date.getMilliseconds()).padStart(3, '0') + '0'.repeat(6);
+  const ns = String(date.getUTCMilliseconds()).padStart(3, '0') + '0'.repeat(6);
   /*
    * 置換元と置換先の組み合わせを定義する
    */
   const replaceDict = {
     /* eslint-disable sort-keys */
     '%%': '%',
-    '%Y': String(date.getFullYear()),
-    '%-m': String(date.getMonth() + 1),
-    '%m': String(date.getMonth() + 1).padStart(2, '0'),
-    '%-d': String(date.getDate()),
-    '%d': String(date.getDate()).padStart(2, '0'),
-    '%-H': String(date.getHours()),
-    '%H': String(date.getHours()).padStart(2, '0'),
-    '%-M': String(date.getMinutes()),
-    '%M': String(date.getMinutes()).padStart(2, '0'),
-    '%-S': String(date.getSeconds()),
-    '%S': String(date.getSeconds()).padStart(2, '0'),
+    '%Y': String(date.getUTCFullYear()),
+    '%-m': String(date.getUTCMonth() + 1),
+    '%m': String(date.getUTCMonth() + 1).padStart(2, '0'),
+    '%-d': String(date.getUTCDate()),
+    '%d': String(date.getUTCDate()).padStart(2, '0'),
+    '%-H': String(date.getUTCHours()),
+    '%H': String(date.getUTCHours()).padStart(2, '0'),
+    '%-M': String(date.getUTCMinutes()),
+    '%M': String(date.getUTCMinutes()).padStart(2, '0'),
+    '%-S': String(date.getUTCSeconds()),
+    '%S': String(date.getUTCSeconds()).padStart(2, '0'),
     '%s': String(date.getTime()),
     '%N': ns,
     '%1N': ns.substr(0, 1),
@@ -269,7 +268,7 @@ function formatDate(
    *       冗長な判定は使用していない。
    */
   return format.replace(
-    /%(?:y|-?[mdhms%]|[1-9]n|:{0,2}z)/gi,
+    new RegExp(Object.keys(replaceDict).join('|'), 'g'),
     match => replaceDict[match] || match,
   );
 }

--- a/src/utils/template-functions.js
+++ b/src/utils/template-functions.js
@@ -150,7 +150,11 @@ Object.assign(exports, { yahooStyleURLBreaker });
  *     32400（`9 * 60 * 60`の計算結果）を指定する
  * @see https://github.com/sounisi5011/novel-dinner-from-twitter-977500688279154688/blob/9413effa03c43ac512b9d1e59c5e4f236d9f6f3d/src/pug/_funcs.pug#L52-L188
  */
-function formatDate(date, format = '%Y-%m-%dT%H:%M:%S%:z', timezoneSec = NaN) {
+function formatDate(
+  date,
+  format = '%Y-%m-%dT%H:%M:%S%:z',
+  timezoneSec = undefined,
+) {
   /*
    * 引数の型チェックを行う
    */
@@ -168,45 +172,44 @@ function formatDate(date, format = '%Y-%m-%dT%H:%M:%S%:z', timezoneSec = NaN) {
         `  buy it's value: ${JSON.stringify(format)}.`,
     );
   }
+  if (!Number.isFinite(timezoneSec)) {
+    throw new TypeError(
+      'formatDate(date, format, timezoneSec):\n' +
+        `  timezoneSec parameter must be finite number.\n` +
+        `  buy it's value: ${JSON.stringify(timezoneSec)}.`,
+    );
+  }
   /*
-   * timezoneSecパラメータの値を数値へ型変換する。
-   * 同時に、小数部を切り捨てる。
+   * timezoneSecパラメータの小数部を切り捨てる。
    */
   timezoneSec = Math.trunc(timezoneSec);
   /*
    * Dateオブジェクトから、タイムゾーンの秒数を取得する
    */
   const systemTimezoneSec = date.getTimezoneOffset() * -1 * 60;
-  if (isFinite(timezoneSec)) {
-    /*
-     * timezoneSecの値が範囲内かを判定
-     */
-    if (!(-(24 * 3600) < timezoneSec)) {
-      throw new TypeError(
-        'formatDate(date, format, timezoneSec):\n' +
-          `  timezoneSec parameter must be greater than ${-(24 * 3600)} ` +
-          `( ${-(24 * 3600)} < timezoneSec ).\n` +
-          `  buy it's value: ${timezoneSec}.`,
-      );
-    } else if (!(timezoneSec < 24 * 3600)) {
-      throw new TypeError(
-        'formatDate(date, format, timezoneSec):\n' +
-          `  timezoneSec parameter must be less than ${24 * 3600} ` +
-          `( timezoneSec < ${24 * 3600} ).\n` +
-          `  buy it's value: ${timezoneSec}.`,
-      );
-    }
-    /*
-     * タイムゾーンに合わせて、Dateオブジェクトの時間をずらす
-     */
-    const unixtime = date.getTime();
-    date = new Date(unixtime - (systemTimezoneSec - timezoneSec) * 1000);
-  } else {
-    /*
-     * タイムゾーンの指定が無い場合、Dateオブジェクトのタイムゾーンから求める
-     */
-    timezoneSec = systemTimezoneSec;
+  /*
+   * timezoneSecの値が範囲内かを判定
+   */
+  if (!(-(24 * 3600) < timezoneSec)) {
+    throw new TypeError(
+      'formatDate(date, format, timezoneSec):\n' +
+        `  timezoneSec parameter must be greater than ${-(24 * 3600)} ` +
+        `( ${-(24 * 3600)} < timezoneSec ).\n` +
+        `  buy it's value: ${timezoneSec}.`,
+    );
+  } else if (!(timezoneSec < 24 * 3600)) {
+    throw new TypeError(
+      'formatDate(date, format, timezoneSec):\n' +
+        `  timezoneSec parameter must be less than ${24 * 3600} ` +
+        `( timezoneSec < ${24 * 3600} ).\n` +
+        `  buy it's value: ${timezoneSec}.`,
+    );
   }
+  /*
+   * タイムゾーンに合わせて、Dateオブジェクトの時間をずらす
+   */
+  const unixtime = date.getTime();
+  date = new Date(unixtime - (systemTimezoneSec - timezoneSec) * 1000);
   /*
    * タイムゾーンの文字列に使用する値を求める
    */


### PR DESCRIPTION
JSTは「Japan Standard Time」の他に「Jerusalem Standard Time」の略称とも捉えられる曖昧さがあるため、JSTの変更、または削除を試みる。

参考：[タイムゾーン呪いの書 - Qiita #"JST": Jerusalem Standard Time?](https://qiita.com/dmikurube/items/15899ec9de643e91497c#jst-jerusalem-standard-time)