### PR TITLE
Twitter Cardの画像の初期値を空文字列にする

### DIFF
--- a/src/pages/_head/ogp.pug
+++ b/src/pages/_head/ogp.pug
@@ -35,14 +35,10 @@ if twitterCardDescription
   meta(name="twitter:description" content=twitterCardDescription)
 if twitterCardTitle
   meta(name="twitter:title" content=twitterCardTitle)
-if twitterCardImageList
-  each imageData in twitterCardImageList
-    if imageData
-      -
-        const imageURL = canonicalURL(
-          rootURL,
-          typeof imageData === 'object' ? imageData.url : imageData
-        );
-      meta(name="twitter:image" content=imageURL)
-      if imageData.alt
-        meta(name="twitter:image:alt" content=imageData.alt)
+each imageData in twitterCardImageList || [null]
+  -
+    const imagePath = (typeof imageData === 'object' && imageData) ? imageData.url : imageData;
+    const imageURL = imagePath ? canonicalURL(rootURL, imagePath) : '';
+  meta(name="twitter:image" content=imageURL)
+  if typeof imageData === 'object' && imageData && imageData.alt
+    meta(name="twitter:image:alt" content=imageData.alt)

--- a/src/pages/index.pug
+++ b/src/pages/index.pug
@@ -5,6 +5,7 @@ localPageStyles:
   - /root.css
 preloadDependencies:
   - /images/my-symbol.svg
+twitterCardImageList: []
 socialLinkList:
   - type: twitter
     screenName: sounisi5011


### PR DESCRIPTION
resolve #50

> [OGPのドキュメント](https://ogp.me/#metadata)によれば、画像のプロパティ`<meta property="og:image">`は必須です。
> 一方、[Twitter Cardのドキュメント](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary)では、画像のプロパティ`<meta name="twitter:image">`は**必須ではありません**。
> 加えて、`<meta name="twitter:image">`に指定する画像には、ウェブサイトのロゴなどは使用するべきではないと記述されています。
> 
> > You should not use a generic image such as your website logo, author photo, or other image that spans multiple pages.
> 
> 現在、Twitter Cardのプロパティは初期状態では追加されず、OGPの画像をそのまま流用します。
> しかし、[OGPの画像の初期値には、Webサイトのロゴを指定しています](https://github.com/sounisi5011/sounisi5011.jp/blob/793dd1a52b1598145d6ed7d8ee761348200c699d/index.js#L46-L52)。
> これは、Twitter Cardの推奨設定とは異なるため、Twitter Cardの画像の初期値を空文字列にすることを提案します。

---

- [x] Twitter Cardの`<meta name="twitter:image">`に空文字列を指定できるように修正
- [x] Twitter Cardの`<meta name="twitter:image">`が空の属性値を受け入れるか検証
