### PR TITLE
共有ボタンのスタイルを修正

### DIFF
--- a/src/scripts/paragraphs-share.js
+++ b/src/scripts/paragraphs-share.js
@@ -780,30 +780,11 @@
         }
         dialogElem.showModal();
         if (cssSupports('position: fixed') === false) {
-          const top =
+          dialogElem.style.top =
             window.pageYOffset +
-            getWindowHeight(dialogElem.ownerDocument || document) / 2;
-          dialogElem.style.top = top + 'px';
-          dialogElem.firstChild.appendChild(
-            document.createTextNode(
-              'top: ' +
-                top +
-                ' / pageYOffset: ' +
-                window.pageYOffset +
-                ' / WindowHeight: ' +
-                getWindowHeight(dialogElem.ownerDocument || document),
-            ),
-          );
+            getWindowHeight(dialogElem.ownerDocument || document) / 2 +
+            'px';
         }
-
-        dialogElem.firstChild.appendChild(
-          document.createTextNode(
-            "cssSupports('position: fixed'): " +
-              cssSupports('position: fixed') +
-              " / cssSupports('position', 'fixed'): " +
-              cssSupports('position', 'fixed'),
-          ),
-        );
       };
     }
   }

--- a/src/scripts/paragraphs-share.js
+++ b/src/scripts/paragraphs-share.js
@@ -3,6 +3,12 @@
   const CSS = window.CSS || {};
   const fragmentIdAttr = 'data-fragment-id';
 
+  /**
+   * @see https://dev.opera.com/articles/opera-mini-and-javascript/#detecting-opera-mini-using-the-windowoperamini-property
+   */
+  const isOperaMini =
+    Object.prototype.toString.call(window.operamini) === '[object OperaMini]';
+
   function sign(number) {
     return number < 0 ? -1 : +1;
   }
@@ -766,7 +772,11 @@
           }),
         ]),
       );
-      document.body.appendChild(dialogElem);
+      if (isOperaMini) {
+        footerElem.insertBefore(dialogElem, shareAreaElem.nextSibling);
+      } else {
+        document.body.appendChild(dialogElem);
+      }
 
       const dialogClassList = dialogElem.classList;
       share = ({ title = document.title, text, url }) => {
@@ -778,7 +788,9 @@
         } else {
           dialogClassList.add('hide-text');
         }
-        if (cssSupports('position: fixed') === false) {
+        if (isOperaMini) {
+          dialogElem.style.position = 'static';
+        } else if (cssSupports('position: fixed') === false) {
           dialogElem.style.top =
             window.pageYOffset +
             getWindowHeight(dialogElem.ownerDocument || document) / 2 +

--- a/src/scripts/paragraphs-share.js
+++ b/src/scripts/paragraphs-share.js
@@ -778,13 +778,13 @@
         } else {
           dialogClassList.add('hide-text');
         }
-        dialogElem.showModal();
         if (cssSupports('position: fixed') === false) {
           dialogElem.style.top =
             window.pageYOffset +
             getWindowHeight(dialogElem.ownerDocument || document) / 2 +
             'px';
         }
+        dialogElem.showModal();
       };
     }
   }

--- a/src/scripts/paragraphs-share.js
+++ b/src/scripts/paragraphs-share.js
@@ -784,7 +784,7 @@
             window.pageYOffset +
             getWindowHeight(dialogElem.ownerDocument || document) / 2;
           dialogElem.style.top = top + 'px';
-          dialogElem.appendChild(
+          dialogElem.firstChild.appendChild(
             document.createTextNode(
               'top: ' +
                 top +
@@ -796,11 +796,11 @@
           );
         }
 
-        dialogElem.appendChild(
+        dialogElem.firstChild.appendChild(
           document.createTextNode(
             "cssSupports('position: fixed'): " +
               cssSupports('position: fixed') +
-              "cssSupports('position', 'fixed'): " +
+              " / cssSupports('position', 'fixed'): " +
               cssSupports('position', 'fixed'),
           ),
         );

--- a/src/scripts/paragraphs-share.js
+++ b/src/scripts/paragraphs-share.js
@@ -25,6 +25,12 @@
     return retval;
   }
 
+  const cssSupports =
+    typeof CSS.supports === 'function'
+      ? CSS.supports
+      : typeof window.supportsCSS === 'function'
+      ? window.supportsCSS
+      : () => null;
   const cssEscape =
     typeof CSS.escape === 'function'
       ? CSS.escape
@@ -773,6 +779,12 @@
           dialogClassList.add('hide-text');
         }
         dialogElem.showModal();
+        if (cssSupports('position', 'fixed') === false) {
+          dialogElem.style.top =
+            window.pageYOffset +
+            getWindowHeight(dialogElem.ownerDocument || document) / 2 +
+            'px';
+        }
       };
     }
   }

--- a/src/scripts/paragraphs-share.js
+++ b/src/scripts/paragraphs-share.js
@@ -780,10 +780,20 @@
         }
         dialogElem.showModal();
         if (cssSupports('position', 'fixed') === false) {
-          dialogElem.style.top =
+          const top =
             window.pageYOffset +
-            getWindowHeight(dialogElem.ownerDocument || document) / 2 +
-            'px';
+            getWindowHeight(dialogElem.ownerDocument || document) / 2;
+          dialogElem.style.top = top + 'px';
+          dialogElem.appendChild(
+            document.createTextNode(
+              'top: ' +
+                top +
+                ' / pageYOffset: ' +
+                window.pageYOffset +
+                ' / WindowHeight: ' +
+                getWindowHeight(dialogElem.ownerDocument || document),
+            ),
+          );
         }
       };
     }

--- a/src/scripts/paragraphs-share.js
+++ b/src/scripts/paragraphs-share.js
@@ -779,7 +779,7 @@
           dialogClassList.add('hide-text');
         }
         dialogElem.showModal();
-        if (cssSupports('position', 'fixed') === false) {
+        if (cssSupports('position: fixed') === false) {
           const top =
             window.pageYOffset +
             getWindowHeight(dialogElem.ownerDocument || document) / 2;
@@ -795,6 +795,15 @@
             ),
           );
         }
+
+        dialogElem.appendChild(
+          document.createTextNode(
+            "cssSupports('position: fixed'): " +
+              cssSupports('position: fixed') +
+              "cssSupports('position', 'fixed'): " +
+              cssSupports('position', 'fixed'),
+          ),
+        );
       };
     }
   }

--- a/src/styles/paragraphs-share.less
+++ b/src/styles/paragraphs-share.less
@@ -60,6 +60,10 @@ footer.page {
     margin-bottom: 0;
   }
 
+  @supports not ((position: sticky) and (position: fixed)) {
+    position: relative;
+  }
+
   & > .share-area {
     @button-bg-color: #000;
     @button-text-color: #fff;
@@ -70,6 +74,11 @@ footer.page {
     right: 1em;
     margin: 0;
     font-size: larger;
+
+    @supports not (position: fixed) {
+      position: absolute;
+      bottom: @share-area-height - 1em;
+    }
 
     @supports (position: sticky) {
       position: absolute;

--- a/src/styles/paragraphs-share.less
+++ b/src/styles/paragraphs-share.less
@@ -274,6 +274,10 @@ dialog.share-dialog {
   padding: 0;
   background: transparent;
 
+  @supports not (position: fixed) {
+    position: absolute;
+  }
+
   .backdrop() {
     background-color: rgba(0, 0, 0, 0.5);
   }

--- a/src/styles/paragraphs-share.less
+++ b/src/styles/paragraphs-share.less
@@ -77,7 +77,7 @@ footer.page {
 
     @supports not (position: fixed) {
       position: absolute;
-      bottom: @share-area-height - 1em;
+      bottom: (@share-area-height - 1em) * -1;
     }
 
     @supports (position: sticky) {

--- a/src/styles/paragraphs-share.less
+++ b/src/styles/paragraphs-share.less
@@ -55,13 +55,13 @@ footer.page {
 
   margin-bottom: @share-area-height;
 
-  @supports (position: sticky) {
-    margin-top: @share-area-height;
+  @supports not (position: fixed) {
     margin-bottom: 0;
   }
 
-  @supports not ((position: sticky) and (position: fixed)) {
-    position: relative;
+  @supports (position: sticky) {
+    margin-top: @share-area-height;
+    margin-bottom: 0;
   }
 
   & > .share-area {
@@ -76,7 +76,11 @@ footer.page {
     font-size: larger;
 
     @supports not (position: fixed) {
-      position: absolute;
+      position: relative;
+      left: 0;
+      right: 0;
+      margin-left: 1em;
+      margin-right: 1em;
     }
 
     @supports (position: sticky) {
@@ -113,8 +117,10 @@ footer.page {
       bottom: 0;
       margin-bottom: 1em;
 
-      @supports not (position: fixed) {
-        margin-bottom: (@share-area-height - 1em) * -1;
+      @supports not ((position: fixed) and (position: sticky)) {
+        position: relative;
+        display: inline-block;
+        margin-top: 1em;
       }
     }
 

--- a/src/styles/paragraphs-share.less
+++ b/src/styles/paragraphs-share.less
@@ -77,7 +77,6 @@ footer.page {
 
     @supports not (position: fixed) {
       position: absolute;
-      bottom: (@share-area-height - 1em) * -1;
     }
 
     @supports (position: sticky) {
@@ -113,6 +112,10 @@ footer.page {
       position: absolute;
       bottom: 0;
       margin-bottom: 1em;
+
+      @supports not (position: fixed) {
+        margin-bottom: (@share-area-height - 1em) * -1;
+      }
     }
 
     & > .left-menu {


### PR DESCRIPTION
`position: fixed`に対応していない環境（Opera Miniなど）向けのスタイルを追加する。
fix #68