### PR TITLE
HTMLバリデータの導入

### DIFF
--- a/index.js
+++ b/index.js
@@ -344,6 +344,9 @@ Metalsmith(__dirname)
   )
   .build(err => {
     if (err) {
+      if (err.stack && !err.stack.includes(err.message)) {
+        console.error(err.message);
+      }
       throw err;
     }
   });

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const babel = require('metalsmith-babel');
 const collections = require('metalsmith-collections');
 const directoryMetadata = require('metalsmith-directory-metadata');
 const excerpts = require('metalsmith-excerpts');
+const htmlValidator = require('metalsmith-html-validator');
 const ignore = require('metalsmith-ignore');
 const permalinks = require('metalsmith-permalinks');
 const postcss = require('metalsmith-postcss');
@@ -331,6 +332,7 @@ Metalsmith(__dirname)
       ],
     }),
   )
+  .use(htmlValidator())
   .use(
     sitemap({
       hostname(files, metalsmith) {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "metalsmith-collections": "^0.9.0",
     "metalsmith-directory-metadata": "^1.0.0",
     "metalsmith-excerpts": "^1.2.0",
+    "metalsmith-html-validator": "^1.0.0",
     "metalsmith-ignore": "^1.0.0",
     "metalsmith-in-place": "^4.4.0",
     "metalsmith-permalinks": "^2.2.0",

--- a/src/pages/_layout.pug
+++ b/src/pages/_layout.pug
@@ -22,7 +22,7 @@ if qrCodeImageFiles
       rootInlineStyle['--header-url-max-lines'] = urlSegmentCount;
     }
 doctype html
-html(lang="ja" style=rootInlineStyle)
+html(lang="jap" style=rootInlineStyle)
   head(prefix="og: http://ogp.me/ns#")
     block head
       meta(charset="utf-8")

--- a/src/pages/_layout.pug
+++ b/src/pages/_layout.pug
@@ -22,7 +22,7 @@ if qrCodeImageFiles
       rootInlineStyle['--header-url-max-lines'] = urlSegmentCount;
     }
 doctype html
-html(lang="jap" style=rootInlineStyle)
+html(lang="ja" style=rootInlineStyle)
   head(prefix="og: http://ogp.me/ns#")
     block head
       meta(charset="utf-8")

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,7 +1024,7 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/glob@^7.1.1":
+"@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -1112,10 +1112,23 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
+"@types/rimraf@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-2.0.2.tgz#7f0fc3cf0ff0ad2a99bb723ae1764f30acaf8b6e"
+  integrity sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
+
 "@types/semver@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
   integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
+
+"@types/tmp@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
+  integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
 
 "@types/tough-cookie@*":
   version "2.3.5"
@@ -2816,6 +2829,15 @@ create-error-class@^3.0.0:
   integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
   dependencies:
     capture-stack-trace "^1.0.0"
+
+cross-spawn@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.0.tgz#21ef9470443262f33dba80b2705a91db959b2e03"
+  integrity sha512-6U/8SMK2FBNnB21oQ4+6Nsodxanw1gTkntYA2zBdkFYFu3ZDx65P2ONEXGSvob/QS6REjVHQ9zxzdOafwFdstw==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -6248,6 +6270,24 @@ metalsmith-excerpts@^1.2.0:
     cheerio "^0.15.0"
     debug "~0.7.4"
 
+metalsmith-html-validator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/metalsmith-html-validator/-/metalsmith-html-validator-1.0.0.tgz#23073ea12adbedf9685df8658e1c8dac80eb5503"
+  integrity sha512-MmdV3AmR3n/AMSrqo/k+6EBSfwU5Q0CKMTi4yyVIfIaDoKXChkpw7TVo1RcyFjzMl5g8wzwyKA1l2nqx30b9sw==
+  dependencies:
+    "@types/metalsmith" "2.3.0"
+    "@types/rimraf" "2.0.2"
+    "@types/tmp" "0.1.0"
+    cross-spawn "7.0.0"
+    debug "4.1.1"
+    deep-freeze-strict "1.1.1"
+    multimatch "4.0.0"
+    rimraf "3.0.0"
+    shell-escape "0.2.0"
+    signal-exit "3.0.2"
+    tmp "0.1.0"
+    vnu-jar "19.9.4"
+
 metalsmith-ignore@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/metalsmith-ignore/-/metalsmith-ignore-1.0.0.tgz#9a1eb87659c5de1821efa6bea903748b49d47ffc"
@@ -7386,7 +7426,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-key@^3.0.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.0.tgz#99a10d870a803bdd5ee6f0470e58dfcd2f9a54d3"
   integrity sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==
@@ -8319,6 +8359,13 @@ rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.6.1, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+  dependencies:
+    glob "^7.1.3"
+
 run-async@^2.2.0, run-async@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -8482,6 +8529,11 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
+shell-escape@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/shell-escape/-/shell-escape-0.2.0.tgz#68fd025eb0490b4f567a027f0bf22480b5f84133"
+  integrity sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM=
+
 shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
@@ -8492,7 +8544,7 @@ shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@3.0.2, signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
@@ -9118,6 +9170,13 @@ tmp@0.0.33, tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+tmp@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
+
 to-buffer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
@@ -9535,6 +9594,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vnu-jar@19.9.4:
+  version "19.9.4"
+  resolved "https://registry.yarnpkg.com/vnu-jar/-/vnu-jar-19.9.4.tgz#fa04135dee3df1cdb1bbcbcd11fc40b73fd39d8a"
+  integrity sha512-x91WyaNr1oPJaYZkbyMElRyV60BUaxPuhm3zXXjlFOpW3E2KavPWlyohX0LTf6gX7/tujIMgLE5UGc0jn7o4XQ==
 
 void-elements@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
[metalsmith-html-validator]を導入して、HTMLの検証を行うようにする。

[metalsmith-html-validator]: https://www.npmjs.com/package/metalsmith-html-validator

- [x] [metalsmith-html-validator]を依存関係に追加
- [x] [metalsmith-html-validator]の設定を追加
- [x] [metalsmith-html-validator]がNetlifyで動作することを確認

resolve #65
