### PR TITLE
生成済み短縮URLの一覧の暗号化方式を修正

### DIFF
--- a/plugins/metalsmith/url-shortener/binary-file-utils.js
+++ b/plugins/metalsmith/url-shortener/binary-file-utils.js
@@ -64,16 +64,20 @@ class DataChunk {
    * @param {number} value
    */
   setInt(chunkType, value) {
-    if (!(Number.isInteger(value) && value <= 0xffffffff)) {
+    if (!(Number.isInteger(value) && value >= 0x00 && value <= 0xffffffff)) {
       throw new TypeError(
-        `value引数は${0xffffffff}以下の整数である必要があります`,
+        `value引数は0以上${0xffffffff}以下の整数である必要があります`,
       );
     }
     const intList = [];
-    let int = value;
-    while (int) {
-      intList.push(int & 0xff);
-      int = int >>> 8;
+    if (value <= 0xff) {
+      intList.push(value);
+    } else {
+      let int = value;
+      while (int) {
+        intList.push(int & 0xff);
+        int = int >>> 8;
+      }
     }
     this.setBuffer(chunkType, Buffer.from(intList));
   }

--- a/plugins/metalsmith/url-shortener/binary-file-utils.js
+++ b/plugins/metalsmith/url-shortener/binary-file-utils.js
@@ -1,0 +1,143 @@
+class DataChunk {
+  /**
+   * @param {Buffer} data
+   * @param {number} index
+   */
+  constructor(data = null, index = 0) {
+    /**
+     * @private
+     * @type {Map.<number, Buffer>}
+     */
+    this._dataMap = new Map();
+
+    if (data) {
+      const startIndex = index;
+      const { dataList, endIndex } = this._readDataChunks(data, startIndex);
+      for (const { chunkType, data } of dataList) {
+        this.appendBuffer(chunkType, data);
+      }
+      /** @private */
+      this._data = data.subarray(startIndex, endIndex);
+    }
+  }
+
+  /**
+   * @param {number} chunkType
+   * @returns {Buffer|undefined}
+   */
+  getBuffer(chunkType) {
+    return this._dataMap.get(chunkType);
+  }
+
+  /**
+   * @param {number} chunkType
+   * @param {Buffer} data
+   */
+  setBuffer(chunkType, data) {
+    if (
+      !(chunkType >= 0x00 && chunkType <= 0xff && Number.isInteger(chunkType))
+    ) {
+      throw new RangeError(
+        `chunkType引数は${0x00}以上${0xff}以下の整数である必要があります`,
+      );
+    }
+    if (data.length < 1) {
+      throw new TypeError(`空のBufferを設定することはできません`);
+    }
+    this._data = null;
+    this._dataMap.set(chunkType, data);
+  }
+
+  /**
+   * @param {number} chunkType
+   * @param {Buffer} data
+   */
+  appendBuffer(chunkType, data) {
+    const prevData = this.getBuffer(chunkType);
+    this.setBuffer(
+      chunkType,
+      prevData ? Buffer.concat([prevData, data]) : data,
+    );
+  }
+
+  /**
+   * @param {number} chunkType
+   * @returns {number|undefined}
+   */
+  getInt(chunkType) {
+    const data = this.getBuffer(chunkType);
+    if (!data) return undefined;
+    return data.reduce((value, int, index) => value | (int << (8 * index)), 0);
+  }
+
+  /**
+   * @param {number} chunkType
+   * @param {number} value
+   */
+  setInt(chunkType, value) {
+    if (!(Number.isInteger(value) && value <= 0xffffffff)) {
+      throw new TypeError(
+        `value引数は${0xffffffff}以下の整数である必要があります`,
+      );
+    }
+    const intList = [];
+    let int = value;
+    while (int) {
+      intList.push(int & 0xff);
+      int = int >>> 8;
+    }
+    this.setBuffer(chunkType, Buffer.from(intList));
+  }
+
+  toBuffer() {
+    if (!this._data) {
+      this._data = Buffer.concat(
+        [...this._dataMap]
+          .map(([chunkType, data]) => this._createDataChunk(chunkType, data))
+          .reduce((bufList, list) => [...bufList, ...list], [])
+          .concat(Buffer.from([0x00])),
+      );
+    }
+    return this._data;
+  }
+
+  /**
+   * @private
+   * @param {Buffer} data
+   * @param {number} startIndex
+   * @returns {{dataList: {chunkType: number, data: Buffer}[], endIndex: number}}
+   */
+  _readDataChunks(data, startIndex) {
+    const dataList = [];
+    let currentIndex = startIndex;
+    while (true) {
+      const chunkLength = data[currentIndex++];
+      if (chunkLength === 0x00) break;
+      const chunkType = data[currentIndex++];
+      dataList.push({
+        chunkType,
+        data: data.subarray(currentIndex, (currentIndex += chunkLength)),
+      });
+    }
+    return { dataList, endIndex: currentIndex };
+  }
+
+  /**
+   * @private
+   * @param {number} chunkType
+   * @param {Buffer} data
+   * @returns {Buffer[]}
+   */
+  _createDataChunk(chunkType, data) {
+    let index = 0;
+    const list = [];
+    while (index < data.length) {
+      const chunkData = data.subarray(index, (index += 0xff));
+      const chunkLength = chunkData.length;
+      list.push(Buffer.from([chunkLength, chunkType]), chunkData);
+    }
+    return list;
+  }
+}
+
+exports.DataChunk = DataChunk;

--- a/plugins/metalsmith/url-shortener/encrypt.js
+++ b/plugins/metalsmith/url-shortener/encrypt.js
@@ -19,6 +19,7 @@ const { DataChunk } = require('./binary-file-utils');
 
 /**
  * @see https://tools.ietf.org/html/rfc8103#section-1.1
+ * @see https://tools.ietf.org/html/rfc7539#section-2.4
  */
 const KEY_LENGTH = 256 / 8;
 
@@ -37,8 +38,9 @@ exports.encryptToFileData = (key, data) => {
   /**
    * @see https://nodejs.org/api/crypto.html#crypto_ccm_mode
    * @see https://scrapbox.io/nwtgck/AES-GCM%E3%81%AE%E5%88%9D%E6%9C%9F%E5%8C%96%E3%83%99%E3%82%AF%E3%83%88%E3%83%ABIV%E3%81%AF12%E3%83%90%E3%82%A4%E3%83%88%E3%81%8C%E6%8E%A8%E5%A5%A8
+   * @see https://tools.ietf.org/html/rfc7539#section-2.4
    */
-  const iv = crypto.randomBytes(12);
+  const iv = crypto.randomBytes(96 / 8);
   /**
    * @see https://nodejs.org/api/crypto.html#crypto_ccm_mode
    * @see https://tools.ietf.org/html/rfc8103#section-1.1

--- a/plugins/metalsmith/url-shortener/encrypt.js
+++ b/plugins/metalsmith/url-shortener/encrypt.js
@@ -19,12 +19,20 @@ const zlib = require('zlib');
 
 const { DataChunk } = require('./binary-file-utils');
 
+/*
+ * 拡張データのチャンクタイプを定義
+ * Note: 後方互換性を維持するため、既存の値は編集しないでください。
+ */
 const chunkTypeRecord = {
   authTag: 0x00,
   authTagLen: 0x01,
   compressType: 0x10,
 };
 
+/*
+ * 圧縮アルゴリズムの一覧を定義
+ * Note: 後方互換性を維持するため、既存の値は編集しないでください。
+ */
 const compresserRecord = {
   deflate: {
     type: 0x01,
@@ -56,6 +64,10 @@ const KEY_LENGTH = 256 / 8;
 
 exports.KEY_LENGTH = KEY_LENGTH;
 
+/*
+ * 使用する暗号化アルゴリズムを定義
+ * 認証付き暗号を使用する。
+ */
 const supportedAlgorithmList = crypto.getCiphers();
 const algorithm = ['chacha20-poly1305', 'aes-256-gcm'].find(algorithm =>
   supportedAlgorithmList.includes(algorithm),

--- a/plugins/metalsmith/url-shortener/encrypt.js
+++ b/plugins/metalsmith/url-shortener/encrypt.js
@@ -4,34 +4,84 @@
  * @see https://qiita.com/shoichi0599/items/6082b765c1257b71985b
  * @see https://qiita.com/liveasnotes/items/a5e35419242883029e25
  * @see https://www.kwbtblog.com/entry/2019/07/19/155421
+ * @see https://qiita.com/asksaito/items/130863fe9e6a08dcd65d
+ * @see https://jovi0608.hatenablog.com/entry/20160404/1459748671
+ * @see https://crypto.stackovernet.com/ja/q/11505
+ * @see https://gist.github.com/rjz/15baffeab434b8125ca4d783f4116d81
+ * @see https://qiita.com/asksaito/items/1793b8d8b3069b0b8d68
+ * @see https://github.com/sylph01/tokyoex_encryption_with_elixir/blob/master/encryption_with_elixir.md
+ * @see https://scrapbox.io/nwtgck/AES-GCM%E3%81%AE%E5%88%9D%E6%9C%9F%E5%8C%96%E3%83%99%E3%82%AF%E3%83%88%E3%83%ABIV%E3%81%AF12%E3%83%90%E3%82%A4%E3%83%88%E3%81%8C%E6%8E%A8%E5%A5%A8
  */
 
 const crypto = require('crypto');
 
-const ALGORITHM = 'aes-256-ctr';
-const KEY_LENGTH = 32;
-const IV_LENGTH = 16;
+const { DataChunk } = require('./binary-file-utils');
+
+/**
+ * @see https://tools.ietf.org/html/rfc8103#section-1.1
+ */
+const KEY_LENGTH = 256 / 8;
 
 exports.KEY_LENGTH = KEY_LENGTH;
+
+const supportedAlgorithmList = crypto.getCiphers();
+const algorithm = ['chacha20-poly1305', 'aes-256-gcm'].find(algorithm =>
+  supportedAlgorithmList.includes(algorithm),
+);
 
 /**
  * @param {Buffer} key
  * @param {string} data
  */
-exports.encryptToFileData = (
-  key,
-  data,
-  { algorithm = ALGORITHM, iv = crypto.randomBytes(IV_LENGTH) } = {},
-) => {
-  const cipher = crypto.createCipheriv(algorithm, key, iv);
+exports.encryptToFileData = (key, data) => {
+  /**
+   * @see https://nodejs.org/api/crypto.html#crypto_ccm_mode
+   * @see https://scrapbox.io/nwtgck/AES-GCM%E3%81%AE%E5%88%9D%E6%9C%9F%E5%8C%96%E3%83%99%E3%82%AF%E3%83%88%E3%83%ABIV%E3%81%AF12%E3%83%90%E3%82%A4%E3%83%88%E3%81%8C%E6%8E%A8%E5%A5%A8
+   */
+  const iv = crypto.randomBytes(12);
+  /**
+   * @see https://nodejs.org/api/crypto.html#crypto_ccm_mode
+   * @see https://tools.ietf.org/html/rfc8103#section-1.1
+   */
+  const authTagLength = 16;
 
-  const algorithmData = Buffer.from(algorithm);
+  /*
+   * 暗号化
+   */
+  const cipher = crypto.createCipheriv(algorithm, key, iv, { authTagLength });
+  const encryptedDataPart1 = cipher.update(data);
+  const encryptedDataPart2 = cipher.final();
+
+  /*
+   * 拡張データを作成
+   */
+  const extensionData = new DataChunk();
+  extensionData.setInt(0xa0, authTagLength);
+  try {
+    const authTag = cipher.getAuthTag();
+    extensionData.setBuffer(0xa1, authTag);
+  } catch (error) {
+    if (
+      !(
+        error.code === 'ERR_CRYPTO_INVALID_STATE' &&
+        error.message === 'Invalid state for operation getAuthTag'
+      )
+    ) {
+      throw error;
+    }
+  }
+
+  /*
+   * 暗号化データをファイル用の形式に変換
+   */
+  const algorithmData = Buffer.from('\x00' + algorithm);
   const encryptedFileData = Buffer.concat([
     Buffer.from([algorithmData.length, iv.length]),
     algorithmData,
     iv,
-    cipher.update(data),
-    cipher.final(),
+    extensionData.toBuffer(),
+    encryptedDataPart1,
+    encryptedDataPart2,
   ]);
   return encryptedFileData;
 };
@@ -42,15 +92,68 @@ exports.encryptToFileData = (
  */
 exports.decryptFromFileData = (key, encryptedFileData) => {
   let index = 0;
+
+  /*
+   * 暗号化アルゴリズムとIVのデータ長を読み取る
+   */
   const algorithmLength = encryptedFileData[index];
   const ivLength = encryptedFileData[++index];
+
+  /*
+   * 暗号化アルゴリズムを読み取る
+   */
   const algorithmData = encryptedFileData.subarray(
     ++index,
     (index += algorithmLength),
   );
+  let algorithm = '';
+  let allowExtension = false;
+  if (algorithmData[0] === 0x00) {
+    /*
+     * 先頭が0x00の場合は、拡張データを含むものとして処理する
+     */
+    algorithm = algorithmData.subarray(1).toString();
+    allowExtension = true;
+  } else {
+    algorithm = algorithmData.toString();
+  }
+
+  /*
+   * IVを読み取る
+   */
   const iv = encryptedFileData.subarray(index, (index += ivLength));
+
+  /*
+   * 拡張データを読み取る
+   */
+  let extensionData = new DataChunk();
+  if (allowExtension) {
+    extensionData = new DataChunk(encryptedFileData, index);
+    index += extensionData.toBuffer().length;
+  }
+
+  /*
+   * 暗号データを読み取る
+   */
   const encryptedData = encryptedFileData.subarray(index);
 
-  const decipher = crypto.createDecipheriv(algorithmData.toString(), key, iv);
+  /*
+   * 復号のオプションを設定
+   */
+  const options = {};
+  {
+    const authTagLength = extensionData.getInt(0xa0);
+    if (typeof authTagLength === 'number')
+      options.authTagLength = authTagLength;
+  }
+
+  /*
+   * 復号
+   */
+  const decipher = crypto.createDecipheriv(algorithm, key, iv, options);
+  {
+    const authTag = extensionData.getBuffer(0xa1);
+    if (authTag) decipher.setAuthTag(authTag);
+  }
   return Buffer.concat([decipher.update(encryptedData), decipher.final()]);
 };

--- a/plugins/metalsmith/url-shortener/encrypt.js
+++ b/plugins/metalsmith/url-shortener/encrypt.js
@@ -25,7 +25,7 @@ exports.encryptToFileData = (
 ) => {
   const cipher = crypto.createCipheriv(algorithm, key, iv);
 
-  const algorithmData = Buffer.from(ALGORITHM);
+  const algorithmData = Buffer.from(algorithm);
   const encryptedFileData = Buffer.concat([
     Buffer.from([algorithmData.length, iv.length]),
     algorithmData,

--- a/plugins/metalsmith/url-shortener/index.js
+++ b/plugins/metalsmith/url-shortener/index.js
@@ -130,7 +130,7 @@ exports.init = opts => {
         filename2url(options.urlListFilename, options.rootURL),
       );
       if (res.ok) {
-        const defsFileData = decryptFromFileData(
+        const defsFileData = await decryptFromFileData(
           encryptKey,
           await res.buffer(),
         );
@@ -193,7 +193,7 @@ exports.generate = () =>
       const defsFileText = [...urlMap]
         .map(({ url, word }) => `${word} ${url}`)
         .join('\n');
-      const defsFileData = encryptToFileData(encryptKey, defsFileText);
+      const defsFileData = await encryptToFileData(encryptKey, defsFileText);
       pluginKit.addFile(files, options.urlListFilename, defsFileData);
 
       /**

--- a/plugins/metalsmith/url-shortener/index.js
+++ b/plugins/metalsmith/url-shortener/index.js
@@ -219,6 +219,7 @@ exports.generate = () =>
                 url = url.substring(options.rootURL.length);
               return [filepath2RootRelativeURL(word), url].join(' ');
             })
+            .sort()
             .join('\n');
         }),
       );


### PR DESCRIPTION
AES-256-CTRを使用していた暗号化方式を、署名による検証機能付きの[認証付き暗号](https://ja.wikipedia.org/wiki/%E8%AA%8D%E8%A8%BC%E4%BB%98%E3%81%8D%E6%9A%97%E5%8F%B7)に変更する。
