### PR TITLE
生成済み短縮URLの一覧のクロールを禁止

### DIFF
--- a/plugins/metalsmith/url-shortener/bin/fetch-shorturl-defs.js
+++ b/plugins/metalsmith/url-shortener/bin/fetch-shorturl-defs.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const fetch = require('node-fetch');
+
+const { decryptFromFileData } = require('../encrypt');
+const { initOptions } = require('../options');
+
+async function main(args) {
+  process.exitCode = 1;
+
+  const { options, encryptKey } = initOptions({
+    rootURL: args[0] || process.env.URL,
+  });
+
+  const url = new URL(options.rootURL);
+  url.pathname = url.pathname.replace(/\/([^/]*)$/, (url, basename) =>
+    basename === options.urlListFilename
+      ? url
+      : url.replace(/\/*$/, `/${options.urlListFilename}`),
+  );
+
+  console.error('fetching %s', url.href);
+  const res = await fetch(url.href);
+  if (!res.ok) {
+    console.error(`${res.status} ${res.statusText}`);
+    return;
+  }
+
+  const defsFileData = await decryptFromFileData(
+    encryptKey,
+    await res.buffer(),
+  );
+  const defsFileText = defsFileData.toString();
+
+  console.log(defsFileText);
+  process.exitCode = 0;
+}
+
+main(process.argv.slice(2));

--- a/plugins/metalsmith/url-shortener/index.js
+++ b/plugins/metalsmith/url-shortener/index.js
@@ -178,13 +178,6 @@ exports.generate = () =>
       const headersFiledata = getOrDefineFiledata(files, '_headers');
       headersFiledata.contents = Buffer.concat([
         headersFiledata.contents,
-        // TODO: Netlifyの仕様確認用。後で消す
-        ...[
-          Buffer.from(
-            `/${options.urlListFilename}\n  X-XXX-Test: foooooooooooooooo\n`,
-          ),
-          Buffer.from(`/*\n  X-XXX-Xest: hogefuga\n`),
-        ],
         Buffer.from(
           (headersFiledata.contents.length === 0 ? [] : [''])
             .concat([

--- a/plugins/metalsmith/url-shortener/index.js
+++ b/plugins/metalsmith/url-shortener/index.js
@@ -176,10 +176,13 @@ exports.generate = () =>
        * @see https://docs.netlify.com/routing/headers/
        */
       const headersFiledata = getOrDefineFiledata(files, '_headers');
+      const isEmptyOrLFEnd =
+        headersFiledata.contents.length === 0 ||
+        headersFiledata.contents.subarray(-1).equals(Buffer.from('\n'));
       headersFiledata.contents = Buffer.concat([
         headersFiledata.contents,
         Buffer.from(
-          (headersFiledata.contents.length === 0 ? [] : [''])
+          (isEmptyOrLFEnd ? [] : [''])
             .concat([
               filename2url(options.urlListFilename, options.rootURL, true)
                 .pathname,

--- a/plugins/metalsmith/url-shortener/options.js
+++ b/plugins/metalsmith/url-shortener/options.js
@@ -1,0 +1,40 @@
+const { KEY_LENGTH } = require('./encrypt');
+
+function trimRightSlash(urlOrFunc) {
+  if (typeof urlOrFunc === 'function') {
+    return function(...args) {
+      const retval = urlOrFunc.apply(this, args);
+      return typeof retval === 'string' ? retval.replace(/\/+$/, '') : retval;
+    };
+  }
+  return trimRightSlash(() => urlOrFunc)();
+}
+
+exports.initOptions = opts => {
+  const options = {
+    wordLength: 4,
+    wordPrefix: '',
+    urlListFilename: '_url-shortener-defs',
+    encryptKeyEnvName: 'METALSMITH_URL_SHORTENER_ENCRYPT_KEY',
+    /** @see https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata */
+    rootURL: process.env.URL,
+    rootURLShrinker: rootURL => rootURL,
+    redirectsReplaceLine: '# url-shortener redirect paths #',
+    ...opts,
+  };
+  options.rootURL = trimRightSlash(options.rootURL);
+  options.rootURLShrinker = trimRightSlash(options.rootURLShrinker);
+
+  const encryptKeyStr = process.env[options.encryptKeyEnvName];
+  if (!encryptKeyStr)
+    throw new Error(`環境変数 ${options.encryptKeyEnvName} を設定してください`);
+  const encryptKey = ['hex', 'base64']
+    .map(encoding => Buffer.from(encryptKeyStr, encoding))
+    .find(buf => buf.length === KEY_LENGTH);
+  if (!encryptKey)
+    throw new Error(
+      `環境変数 ${options.encryptKeyEnvName} の値は${KEY_LENGTH}bytesのバイナリデータをHexまたはBase64で表した値である必要があります`,
+    );
+
+  return { options, encryptKey };
+};

--- a/plugins/metalsmith/url-shortener/package.json
+++ b/plugins/metalsmith/url-shortener/package.json
@@ -2,6 +2,9 @@
   "name": "@sounisi5011/metalsmith-url-shortener",
   "version": "0.0.0",
   "private": true,
+  "bin": {
+    "fetch-shorturl-defs": "./bin/fetch-shorturl-defs.js"
+  },
   "dependencies": {
     "@tanepiper/easypass-2": "^0.2.1",
     "metalsmith-plugin-kit": "^1.0.1",


### PR DESCRIPTION
生成済みの短縮URLを格納した公開ファイルのレスポンスヘッダに`X-Robots-Tag: noindex`を追加し、クローラによる巡回を禁止する。
